### PR TITLE
Refactor events, parameter objects, allow user to set username

### DIFF
--- a/server/game.js
+++ b/server/game.js
@@ -1,6 +1,8 @@
 // Prevent use of undeclared variables
 "use strict";
 
+let players = [];
+
 function Game(io)
 {
     this.io = io;
@@ -13,7 +15,18 @@ Game.prototype.start = function start()
 
 Game.prototype.connect = function connect(socket)
 {
-    this.io.emit("player join", `Socket ${socket.id} connected to server`);
+    // this.io.emit("player join", `Socket ${socket.id} connected to server`);
+
+    socket.on("set username", (userName) =>
+    {
+        if(!players.includes(userName) && (userName !== "" || userName !== " "))
+        {
+            players.push(userName);
+            socket.emit("user set", userName);
+            this.io.emit("player join", `Player ${userName} (${socket.id}) has joined the server`);
+        }
+        else socket.emit("user exists", `${userName} is already taken or empty. Try another user name.`);
+    });
 };
 
 Game.prototype.disconnect = function disconnect(socket)

--- a/server/game.js
+++ b/server/game.js
@@ -17,6 +17,11 @@ Game.prototype.connect = function connect(socket)
 {
     // this.io.emit("player join", `Socket ${socket.id} connected to server`);
 
+    socket.on("disconnect", () =>
+    {
+        this.io.emit("player leave", `Socket ${socket.id} disconnected from server`);
+    });
+
     socket.on("set username", (userName) =>
     {
         if(!players.includes(userName) && (userName !== "" || userName !== " "))
@@ -27,22 +32,19 @@ Game.prototype.connect = function connect(socket)
         }
         else socket.emit("user exists", `${userName} is already taken or empty. Try another user name.`);
     });
-};
 
-Game.prototype.disconnect = function disconnect(socket)
-{
-    this.io.emit("player leave", `Socket ${socket.id} disconnected from server`);
-};
+    // Listen for send message event
+    socket.on("send message", (chatMsg, player, socketID) =>
+    {
+        // Emit a response to message sent event
+        this.io.sockets.emit("message sent", chatMsg, player, socketID);
+    });
 
-Game.prototype.sendMessage = function sendMessage(socket, chatMsg, player)
-{
-    this.io.emit("send message", chatMsg, player);
-};
-
-Game.prototype.sendPrivateMsg = function sendPrivateMsg(socket, chatMsg, sender, recipient)
-{
-    socket.emit("send private msg", `Private message to ${recipient}`, sender, recipient);
-    this.io.to(recipient).emit("send private msg", `Private message from ${sender}`, sender, recipient);
+    socket.on("send private msg", (chatMsg, senderName, recipient) =>
+    {
+        socket.emit("private msg sent", `Private message to ${recipient.name}`);
+        this.io.to(recipient.id).emit("private msg sent", `Private message from ${senderName}`);
+    });
 };
 
 module.exports = Game;

--- a/server/index.js
+++ b/server/index.js
@@ -6,21 +6,6 @@ const game = new Game(server.io);
 server.io.on("connection", (socket) =>
 {
     game.connect(socket);
-
-    socket.on("disconnect", () =>
-    {
-        game.disconnect(socket);
-    });
-
-    socket.on("send message", (chatMsg, player) => 
-    {
-        game.sendMessage(socket, chatMsg, player);
-    });
-
-    socket.on("send private msg", (chatMsg, sender, recipient) =>
-    {
-        game.sendPrivateMsg(socket, chatMsg, sender, recipient);
-    });
 });
 
 game.start();

--- a/src/view/Chat/Chat.jsx
+++ b/src/view/Chat/Chat.jsx
@@ -9,7 +9,8 @@ export default function Chat(props)
     {
         event.preventDefault();
         event.target.reset();
-        props.socket.emit("send message", chatMsg, props.userName);
+        // Emit to send message event
+        props.socket.emit("send message", chatMsg, props.userName, props.socket.id);
     };
 
     const onChange = (event) =>
@@ -17,32 +18,33 @@ export default function Chat(props)
         setChatMsg(event.target.value);
     };
 
-    const onClick = (event, id) =>
+    const onClick = (event, recipient) =>
     {
         event.preventDefault();
-        props.socket.emit("send private msg", "", props.userName, id);
+        props.socket.emit("send private msg", "", props.userName, recipient);
     };
 
     useEffect(() =>
     {
-        props.socket.on("send message", (chatMsg, player) =>
+        // Listen for response from message sent event
+        props.socket.on("message sent", (chatMsg, player, socketID) =>
         {
-            setMessages(prevMessages => [...prevMessages, { player, chatMsg }]);
+            setMessages(prevMessages => [...prevMessages, { player: { name: player, id: socketID }, chatMsg }]);
         });
 
-        props.socket.on("send private msg", (chatMsg, sender, recipient) =>
+        props.socket.on("private msg sent", (chatMsg) =>
         {
-            setMessages(prevMessages => [...prevMessages, { player: "CONSOLE", chatMsg }])
+            setMessages(prevMessages => [...prevMessages, { player: { name: "CONSOLE", id: "0"}, chatMsg }])
         });
 
         props.socket.on("player join", (msg) =>
         {
-            setMessages(prevMessages => [...prevMessages, { player: "CONSOLE", chatMsg: msg }]);
+            setMessages(prevMessages => [...prevMessages, { player: { name: "CONSOLE", id: "0"}, chatMsg: msg }]);
         });
 
         props.socket.on("player leave", (msg) =>
         {
-            setMessages(prevMessages => [...prevMessages, { player: "CONSOLE", chatMsg: msg }]);
+            setMessages(prevMessages => [...prevMessages, { player: { name: "CONSOLE", id: "0"}, chatMsg: msg }]);
         });
     }, []);
 
@@ -55,9 +57,9 @@ export default function Chat(props)
             Messages:<br/>
             {messages.map(msg => 
                 <div>
-                    {msg.player !== props.userName ? 
-                        <a href={msg.player} onClick={event => onClick(event, msg.player)}><strong>{msg.player}</strong></a> : 
-                        <strong>{msg.player}</strong>
+                    {msg.player.name !== props.userName ? 
+                        <a href={msg.player.name} onClick={event => onClick(event, msg.player)}><strong>{msg.player.name}</strong></a> : 
+                        <strong>{msg.player.name}</strong>
                     }  
                     <br/>
                     {msg.chatMsg}

--- a/src/view/Chat/Chat.jsx
+++ b/src/view/Chat/Chat.jsx
@@ -9,7 +9,7 @@ export default function Chat(props)
     {
         event.preventDefault();
         event.target.reset();
-        props.socket.emit("send message", chatMsg, props.socket.id);
+        props.socket.emit("send message", chatMsg, props.userName);
     };
 
     const onChange = (event) =>
@@ -20,7 +20,7 @@ export default function Chat(props)
     const onClick = (event, id) =>
     {
         event.preventDefault();
-        props.socket.emit("send private msg", "", props.socket.id, id);
+        props.socket.emit("send private msg", "", props.userName, id);
     };
 
     useEffect(() =>
@@ -32,7 +32,7 @@ export default function Chat(props)
 
         props.socket.on("send private msg", (chatMsg, sender, recipient) =>
         {
-            setMessages(prevMessages => [...prevMessages, { player: recipient, chatMsg }])
+            setMessages(prevMessages => [...prevMessages, { player: "CONSOLE", chatMsg }])
         });
 
         props.socket.on("player join", (msg) =>
@@ -48,14 +48,14 @@ export default function Chat(props)
 
     return (
         <div>
-            Welcome, <strong>{props.socket.id}</strong>
+            Welcome, <strong>{props.userName}</strong>
             <form onSubmit={onSubmit}>
                 <input type="text" placeholder="Chat Here" onChange={onChange} />
             </form>
             Messages:<br/>
             {messages.map(msg => 
                 <div>
-                    {msg.player !== props.socket.id ? 
+                    {msg.player !== props.userName ? 
                         <a href={msg.player} onClick={event => onClick(event, msg.player)}><strong>{msg.player}</strong></a> : 
                         <strong>{msg.player}</strong>
                     }  

--- a/src/view/Chat/Message.jsx
+++ b/src/view/Chat/Message.jsx
@@ -1,8 +1,0 @@
-import React, { useEffect, useState } from "react";
-
-export default function Message(props)
-{
-    return (
-        <p>{props.chatMsg}</p>
-    );
-}

--- a/src/view/Client/Client.jsx
+++ b/src/view/Client/Client.jsx
@@ -7,16 +7,52 @@ const ENDPOINT = "localhost:3001";
 export default function Client()
 {
     const socket = socketIOClient(ENDPOINT);
+    const [userName, setUsername] = useState("");
+    const [isLoggedIn, setLoggedIn] = useState(false);
+    const [errorMsg, setErrorMsg] = useState("");
+
+    const onSubmit = (event) =>
+    {
+        event.preventDefault();
+        socket.emit("set username", event.target.input.value);
+        event.target.reset();
+    };
 
     useEffect(() =>
     {
+        socket.on("user set", (userName) =>
+        {
+            setUsername(userName);
+            setLoggedIn(true);
+            console.log(`${isLoggedIn} from user set`);
+        });
+
+        socket.on("user exists", (errorMsg) =>
+        {
+            setErrorMsg(errorMsg);
+            setLoggedIn(false);
+            console.log(`${isLoggedIn} from user exists`);
+        });
+
         // Clean up the effect
         return () => socket.disconnect();
     }, []);
 
     return (
-        <p>
-            <Chat socket={socket} />
-        </p>
+        <div>
+            {!isLoggedIn ? 
+                <div>
+                    <form onSubmit={onSubmit}>
+                        Enter a Username:<br/>
+                        <input type="text" name="input" placeholder="Username" />
+                        <button type="submit">Enter the Chat</button>
+                    </form>
+                    <br/>
+                    {errorMsg}
+                </div>
+                :
+                <Chat socket={socket} userName={userName} />
+            }
+        </div>
     );
 }


### PR DESCRIPTION
# Description
**Summary:**
- Events are refactored and all located in `game.js` now
- Each message will save a player object, which will contain their username and socket id, along with the message sent
- User is now able to set a username to enter the chatroom

**Motivation:**
- Code is now cleaner and easier to read
- Easier to distinguish users in chat, instead of solely relying on socket id

**Dependencies:** None

Fixes N/A

# Type of Change
Please delete options that are not relevant, and check those that apply.

- [X] Bug Fix (non-breaking change which fixes an issue)
- [X] New Feature (non-breaking change which adds functionality)
- [X] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation Update

# How Has This Been Tested?
Tested locally, with server configured on port 3001, and client connected to `localhost:3001` via `socket.io-client`.

Provide instructions so that we can reproduce it.
- `npm run dev` for front end
- `npm run server` for backend
- Now go to `localhost:3000`