### PR TITLE
Load textarea for new users upon connecting

### DIFF
--- a/server/game.js
+++ b/server/game.js
@@ -2,6 +2,7 @@
 "use strict";
 
 let players = [];
+let oldText = "";
 
 function Game(io)
 {
@@ -60,7 +61,13 @@ Game.prototype.connect = function connect(socket)
 
     socket.on("update textarea", (text) =>
     {
+        oldText = text;
         this.io.sockets.emit("textarea updated", text);
+    });
+
+    socket.on("get textarea", () =>
+    {
+        socket.emit("receive textarea", oldText);
     });
 };
 

--- a/src/view/Notepad/Notepad.jsx
+++ b/src/view/Notepad/Notepad.jsx
@@ -3,6 +3,16 @@ import React, { useEffect, useState } from "react";
 export default function Notepad(props)
 {
     const [text, setText] = useState("");
+    
+    const getTextArea = () =>
+    {
+        props.socket.emit("get textarea");
+
+        props.socket.on("receive textarea", (text) =>
+        {
+            setText(text);
+        });
+    };
 
     const onChange = (event) =>
     {
@@ -11,6 +21,8 @@ export default function Notepad(props)
 
     useEffect(() =>
     {
+        getTextArea();
+
         props.socket.on("textarea updated", (text) =>
         {
             setText(text);


### PR DESCRIPTION
# Description
**Summary:** The current text in the textarea will load for all new users that join.

**Motivation:** Now it's really real-time

**Dependencies:** None

Fixes N/A

# Type of Change
Please delete options that are not relevant, and check those that apply.

- [X] Bug Fix (non-breaking change which fixes an issue)
- [X] New Feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Tested locally, with server configured on port 3001, and client connected to `localhost:3001` via `socket.io-client`.

Provide instructions so that we can reproduce it.
- `npm run dev` for front end
- `npm run server` for backend
- Now go to `localhost:3000`